### PR TITLE
dile_vt: add GetVideoFrameBufferCapability and GetALlVideoFrameBufferProperty

### DIFF
--- a/dile-libs/include/dile_vt.h
+++ b/dile-libs/include/dile_vt.h
@@ -41,7 +41,9 @@ typedef struct DILE_VT_FRAMEBUFFER_PROPERTY_T
     uint32_t stride;
     uint32_t width;
     uint32_t height;
-    void *ptr;
+
+    // List (per vfb) of lists (per plane) of physical memory offsets
+    uint32_t **ptr;
 } DILE_VT_FRAMEBUFFER_PROPERTY;
 
 typedef struct DILE_VT_RECT_T
@@ -51,6 +53,12 @@ typedef struct DILE_VT_RECT_T
     uint16_t width;
     uint16_t height;
 } DILE_VT_RECT;
+
+typedef struct DILE_VT_FRAMEBUFFER_CAPABILITY_T
+{
+    uint32_t numVfbs;
+    uint32_t numPlanes;
+} DILE_VT_FRAMEBUFFER_CAPABILITY;
 
 typedef enum DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FLAGS_T
 {
@@ -70,3 +78,6 @@ int DILE_VT_GetCurrentVideoFrameBufferProperty(DILE_VT_HANDLE, DILE_VT_FRAMEBUFF
 void DILE_VT_Destroy(DILE_VT_HANDLE);
 int DILE_VT_SetVideoFrameOutputDeviceOutputRegion(DILE_VT_HANDLE, int pDumpLocation, DILE_VT_RECT* rect);
 int DILE_VT_WaitVsync(DILE_VT_HANDLE, int unk1, int unk2);
+
+int DILE_VT_GetVideoFrameBufferCapability(DILE_VT_HANDLE, DILE_VT_FRAMEBUFFER_CAPABILITY*);
+int DILE_VT_GetAllVideoFrameBufferProperty(DILE_VT_HANDLE, DILE_VT_FRAMEBUFFER_CAPABILITY*, DILE_VT_FRAMEBUFFER_PROPERTY*);

--- a/dile-libs/include/dile_vt.h
+++ b/dile-libs/include/dile_vt.h
@@ -60,6 +60,23 @@ typedef struct DILE_VT_FRAMEBUFFER_CAPABILITY_T
     uint32_t numPlanes;
 } DILE_VT_FRAMEBUFFER_CAPABILITY;
 
+typedef struct DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_LIMITATION_T
+{
+    DILE_VT_RECT maxResolution;
+    uint8_t unk;
+    uint8_t supportInputVideoDeInterlacing;
+    uint8_t supportDisplayVideoDeInterlacing;
+    uint8_t supportScaleUp;
+    uint32_t scaleUpLimitWidth;
+    uint32_t scaleUpLimitHeight;
+    uint8_t supportScaleDown;
+    uint8_t unk2;
+    uint8_t unk3;
+    uint8_t unk4;
+    uint32_t scaleDownLimitWidth;
+    uint32_t scaleDownLimitHeight;
+} DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_LIMITATION;
+
 typedef enum DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FLAGS_T
 {
     DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_NOFX = 0x00,
@@ -81,3 +98,4 @@ int DILE_VT_WaitVsync(DILE_VT_HANDLE, int unk1, int unk2);
 
 int DILE_VT_GetVideoFrameBufferCapability(DILE_VT_HANDLE, DILE_VT_FRAMEBUFFER_CAPABILITY*);
 int DILE_VT_GetAllVideoFrameBufferProperty(DILE_VT_HANDLE, DILE_VT_FRAMEBUFFER_CAPABILITY*, DILE_VT_FRAMEBUFFER_PROPERTY*);
+int DILE_VT_GetVideoFrameOutputDeviceLimitation(DILE_VT_HANDLE, DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_LIMITATION*);

--- a/dile-libs/src/dile_vt.c
+++ b/dile-libs/src/dile_vt.c
@@ -9,3 +9,6 @@ int DILE_VT_GetCurrentVideoFrameBufferProperty(DILE_VT_HANDLE handle, DILE_VT_FR
 void DILE_VT_Destroy(DILE_VT_HANDLE handle) {}
 int DILE_VT_SetVideoFrameOutputDeviceOutputRegion(DILE_VT_HANDLE handle, int pDumpLocation, DILE_VT_RECT* rect) { return -1; }
 int DILE_VT_WaitVsync(DILE_VT_HANDLE handle, int unk1, int unk2) { return -1; }
+
+int DILE_VT_GetVideoFrameBufferCapability(DILE_VT_HANDLE handle, DILE_VT_FRAMEBUFFER_CAPABILITY* cap) { return -1; }
+int DILE_VT_GetAllVideoFrameBufferProperty(DILE_VT_HANDLE handle, DILE_VT_FRAMEBUFFER_CAPABILITY* cap, DILE_VT_FRAMEBUFFER_PROPERTY* vfbProp) { return -1; }

--- a/dile-libs/src/dile_vt.c
+++ b/dile-libs/src/dile_vt.c
@@ -12,3 +12,4 @@ int DILE_VT_WaitVsync(DILE_VT_HANDLE handle, int unk1, int unk2) { return -1; }
 
 int DILE_VT_GetVideoFrameBufferCapability(DILE_VT_HANDLE handle, DILE_VT_FRAMEBUFFER_CAPABILITY* cap) { return -1; }
 int DILE_VT_GetAllVideoFrameBufferProperty(DILE_VT_HANDLE handle, DILE_VT_FRAMEBUFFER_CAPABILITY* cap, DILE_VT_FRAMEBUFFER_PROPERTY* vfbProp) { return -1; }
+int DILE_VT_GetVideoFrameOutputDeviceLimitation(DILE_VT_HANDLE vth, DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_LIMITATION* limitation) { return -1; }


### PR DESCRIPTION
These calls allow us to fetch all physical memory offsets in one go.