### PR TITLE
dile_vt: make CreateEx weak

### DIFF
--- a/dile-libs/include/dile_vt.h
+++ b/dile-libs/include/dile_vt.h
@@ -87,7 +87,7 @@ typedef enum DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FLAGS_T
 } DILE_VT_VIDEO_FRAME_OUTPUT_DEVICE_STATE_FLAGS_T;
 
 DILE_VT_HANDLE DILE_VT_Create(unsigned int videoWindowId);
-DILE_VT_HANDLE DILE_VT_CreateEx(unsigned int videoWindowId, int bufferNum);
+DILE_VT_HANDLE DILE_VT_CreateEx(unsigned int videoWindowId, int bufferNum) __attribute__((weak));
 int DILE_VT_Start(DILE_VT_HANDLE);
 int DILE_VT_Stop(DILE_VT_HANDLE);
 int DILE_VT_GetVideoFrameOutputDeviceDumpLocation(DILE_VT_HANDLE, int *pDumpLocation);


### PR DESCRIPTION
This symbol is only present on some versions (and should be used instead of Create)
This helps with handling that situation.